### PR TITLE
Expand contact sections in personen.md

### DIFF
--- a/datenschemata/datenmodell_personen.md
+++ b/datenschemata/datenmodell_personen.md
@@ -185,6 +185,22 @@ Ungeordnete Liste von Tätigkeiten, die die Person im Laufe Ihres Lebens ausgef�
 
 - `Theologe (R0000015) | Erzieher (M0000250) | Lehrer (M0000250) | Seminardirektor (https://www.bsp-permalink.org/)`
 
+### Kontakt – Mit Herrnhutern
+*List of Structured Strings: \<P-ID\> (\<Reference\>)*
+
+Ungeordnete Liste von Personen-IDs innerhalb der Herrnhuter Brüdergemeine, mit denen diese Person nachweislich in Kontakt stand. Zu jedem Kontakt ist eine Quelle in Klammern anzugeben. Die Quellen entsprechen dem Datentyp *References*, d. h. IDs aus der Literatur-Tabelle (beginnend mit `R`), IDs aus der Manuskripte-Tabelle (beginnend mit `M`) oder permanente URLs.
+
+- `P0000123 (R0000456) | P0000789 (M0000102)`
+
+
+### Kontakt – Mit Nicht-Herrnhutern
+*List of Structured Strings: \<P-ID\> (\<Reference\>)*
+
+Ungeordnete Liste von Personen-IDs außerhalb der Herrnhuter Brüdergemeine, mit denen diese Person nachweislich in Kontakt stand. Zu jedem Kontakt ist eine Quelle in Klammern anzugeben. Die Quellen entsprechen dem Datentyp *References*, d. h. IDs aus der Literatur-Tabelle (beginnend mit `R`), IDs aus der Manuskripte-Tabelle (beginnend mit `M`) oder permanente URLs.
+
+- `P0000234 (https://www.example.org/permalink)`
+
+
 ### Botanik - Foki
 *List of Strings*
 


### PR DESCRIPTION
Added sections for contacts with Herrnhut and non-Herrnhut individuals, including structured string formats and source referencing.

closes #56 